### PR TITLE
fileName extracted from request.URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,9 +151,8 @@ FileServer.prototype.serveDirectory = function(rootDirectory, mimeTypes, maxAge 
     }
 
     return function(request, response, fileName) {
-
-        if(fileName===undefined){
-            fileName=request.url.slice(1);
+        if (arguments.length < 3) {
+            fileName = request.url.slice(1);
         } 
 
         const filePath = path.join(rootDirectory, fileName);

--- a/index.js
+++ b/index.js
@@ -151,6 +151,11 @@ FileServer.prototype.serveDirectory = function(rootDirectory, mimeTypes, maxAge 
     }
 
     return function(request, response, fileName) {
+
+        if(fileName===undefined){
+            fileName=request.url.slice(1);
+        } 
+
         const filePath = path.join(rootDirectory, fileName);
 
         const extention = path.extname(filePath).toLowerCase();


### PR DESCRIPTION
this line of code will extract the file name from the request.url.

e.g. localhost:8080/myfile.mp3

Thus all the files within the floder will be served using this code:

  const serveRobots = fileServer.serveDirectory('D:\\tmp\\GHCache', {
    '.mp3':'audio/mpeg',
    '.gif': 'image/gif',
    '.png': 'image/png',
    '.jpg': 'image/jpeg',
  });

  require('http')
    .createServer(serveRobots)
    .listen(8080);
}