### PR TITLE
updated dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
   },
   "homepage": "https://github.com/MauriceButler/file-server",
   "dependencies": {
-    "chokidar": "^2.0.4",
-    "graceful-fs": "^4.1.11",
+    "chokidar": "^3.5.3",
+    "graceful-fs": "^4.2.10",
     "hashr": "^1.0.2",
     "kgo": "^4.0.3",
     "stream-catcher": "^1.0.5"
   },
   "devDependencies": {
-    "proxyquire": "^2.0.1",
-    "tape": "^4.9.1"
+    "proxyquire": "^2.1.3",
+    "tape": "^5.6.0"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Since there is a severity dependencies error (see below) in this library, I have updated dependencies' versions in package.json.

```
Will install file-server@1.0.6, which is a breaking change
node_modules/file-server/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/file-server/node_modules/chokidar
    file-server  >=2.0.0
    Depends on vulnerable versions of chokidar
    node_modules/file-server
```

I have confirmed `npm test` can be done successfully. Could you merge this PR and release it?
